### PR TITLE
bonescript: update image contents

### DIFF
--- a/recipes-misc/payload/bone101.bb
+++ b/recipes-misc/payload/bone101.bb
@@ -1,0 +1,18 @@
+DESCRIPTION = "BeagleBone 101"
+
+inherit allarch
+
+LICENSE = "MIT & LGPLv3 & others"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=f02920251cbdc9b014dc1cbdb2bb95c4"
+
+SRCREV = "be14e41dfc190743657b562b997072b717cfb292"
+SRC_URI = "git://github.com/jadonk/bone101.git"
+
+S = "${WORKDIR}/git"
+
+do_install() {
+	install -d ${D}${datadir}/${PN}
+	cp -a ${S}/* ${D}${datadir}/${PN}
+}
+
+FILES_${PN} += "${datadir}/${PN}"

--- a/recipes-misc/payload/bonescript.bb
+++ b/recipes-misc/payload/bonescript.bb
@@ -1,13 +1,13 @@
 DESCRIPTION = "Scripting tools for the BeagleBoard and BeagleBone"
 
-PR = "r18"
+PR = "r19"
 
 inherit systemd
 
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=659ee0c98db2664403c769d6b9ab50eb"
 
-SRCREV = "dcc2cc5703ad52eaed3b13b4593c4ef90ff0f79b"
+SRCREV = "5e2a23aeb7a4d64c538647f625a3fd13ef015ac7"
 
 SRC_URI = "git://github.com/jadonk/bonescript.git;protocol=git"
 
@@ -30,6 +30,6 @@ SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_SERVICE_${PN} = "bonescript.service bonescript.socket"
 
 FILES_${PN} += "${libdir}/node_modules/bonescript ${base_libdir}/systemd/system ${sysconfdir}/profile.d"
-RDEPENDS_${PN} = "nodejs beaglebone-getting-started"
+RDEPENDS_${PN} = "nodejs bone101"
 
 FILES_${PN}-dbg += "${libdir}/node_modules/bonescript/build/Release/.debug"

--- a/recipes-misc/payload/bonescript.bb
+++ b/recipes-misc/payload/bonescript.bb
@@ -1,40 +1,35 @@
 DESCRIPTION = "Scripting tools for the BeagleBoard and BeagleBone"
 
-PR = "r17"
+PR = "r18"
 
 inherit systemd
 
 LICENSE = "MIT"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=f02920251cbdc9b014dc1cbdb2bb95c4"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=659ee0c98db2664403c769d6b9ab50eb"
 
-SRC_URI = "http://dominion.thruhere.net/koen/angstrom/beaglebone/bonescript-49e08eb9fb96594235cf079a319387416e1545a9.tar.bz2 \
-           file://bonescript-git \
-           file://bone101.service \
-          "
-SRC_URI[md5sum] = "11b167d5ce182188184258ec35df7653"
-SRC_URI[sha256sum] = "71af7e258612c1d1728a068ff205bdd857e08eb84ea3ec9203fcd63a07d24cca"
+SRCREV = "dcc2cc5703ad52eaed3b13b4593c4ef90ff0f79b"
 
-S = "${WORKDIR}/bonescript"
+SRC_URI = "git://github.com/jadonk/bonescript.git;protocol=git"
+
+S = "${WORKDIR}/git"
 
 do_install() {
-	install -d ${D}${localstatedir}/lib/cloud9/
-	cp -a ${S}/* ${D}${localstatedir}/lib/cloud9/
-	cp -a ${S}/.git ${D}${localstatedir}/lib/cloud9/
+	install -d ${D}${libdir}/node_modules/bonescript
+	cp -a ${S}/node_modules/bonescript/* ${D}${libdir}/node_modules/bonescript
 
 	install -d ${D}${base_libdir}/systemd/system
-	install -m 0644 ${WORKDIR}/bone101.service ${D}${base_libdir}/systemd/system
+	install -m 0644 ${S}/systemd/bonescript.service ${D}${base_libdir}/systemd/system
+	install -m 0644 ${S}/systemd/bonescript.socket ${D}${base_libdir}/systemd/system
 
-	rm -f ${D}${localstatedir}/lib/cloud9/node_modules/binary/node_modules/put/test/c/itof
-	rm -f ${D}${localstatedir}/lib/cloud9/node_modules/binary/node_modules/put/test/c/ftoi
+	install -d ${D}${sysconfdir}/profile.d
+	install -m 0755 ${S}/profile.d/node.sh ${D}${sysconfdir}/profile.d
 }
 
 NATIVE_SYSTEMD_SUPPORT = "1"
 SYSTEMD_PACKAGES = "${PN}"
-SYSTEMD_SERVICE_${PN} = "bone101.service"
+SYSTEMD_SERVICE_${PN} = "bonescript.service bonescript.socket"
 
-FILES_${PN} += "${localstatedir} ${base_libdir}/systemd/system"
-CONFFILES_${PN} += "${localstatedir}/lib/cloud9/.git/config"
-RDEPENDS_${PN} = "nodejs cloud9"
-RRECOMMENDS_${PN} = "git"
+FILES_${PN} += "${libdir}/node_modules/bonescript ${base_libdir}/systemd/system ${sysconfdir}/profile.d"
+RDEPENDS_${PN} = "nodejs beaglebone-getting-started"
 
-FILES_${PN}-dbg += "${localstatedir}/lib/cloud9/node_modules/bonescript/build/Release/.debug"
+FILES_${PN}-dbg += "${libdir}/node_modules/bonescript/build/Release/.debug"


### PR DESCRIPTION
- Move to newer bonescript with updated systemd files
- Install bonescript in /usr/lib/node_modules/bonescript
- Add /etc/profile.d/node.sh to set NODE_PATH=/usr/lib/node_modules
- Don't install bonescript .git or examples in the recipe
- This recipe doen't put anything in /var/lib/cloud9 now
